### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/RealViper8/Steamtools/security/code-scanning/1](https://github.com/RealViper8/Steamtools/security/code-scanning/1)

The best way to fix this issue is to explicitly restrict the `permissions` of the GITHUB_TOKEN for the workflow or job. This is done by adding a `permissions` block to either the workflow root or to the specific job (in this case, "build"). Since the workflow has only one job and that job does not require any write access (it just builds and tests), the minimal permissions of `contents: read` are appropriate. To fix, add:

```yaml
permissions:
  contents: read
```

immediately after the workflow name and triggers, before `env:` and `jobs:`. This limits the GITHUB_TOKEN to read-only access to repository contents, adhering to the principle of least privilege. No imports or additional libraries are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
